### PR TITLE
Fixed line 190 and 192 with the correct markup for code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ To enable the `Switch to Desktop` invoke Steam to shut down the `steamos-session
   >
   > ---
   >
-  > '#!/bin/bash'
+  > `#!/bin/bash`
   >
-  > steam -shutdown
+  > `steam -shutdown`
 
 * From the terminal, set the permissions to `steamos-session-select` and then copy the script into `/usr/bin/` folder
 


### PR DESCRIPTION
This is a typo fix that is likely to be causing Switch to Desktop to fail if the instructions are copied and pasted.