### PR TITLE
Added checks if mangoapp exists before use

### DIFF
--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-gamescope --mangoapp -e -- steam -steamdeck -steamos3
+# Assume that MangoHud is not installed
+MANGOAPP_FLAG=""
+
+# Check that mangoapp is available to see 
+if command -v mangoapp &> /dev/null;
+then
+    MANGOAPP_FLAG="--mangoapp"
+else
+    printf "[%s] [Info] 'mangoapp' is not available on your system. Check to see that MangoHud is installed.\n" $0
+    printf "[%s] [Info] Continuing without the '--mangoapp' flag.\n" $0
+fi
+
+gamescope \
+    $MANGOAPP_FLAG \
+    -e -- steam -steamdeck -steamos3


### PR DESCRIPTION
Added a variable in the gamescope-session for the `--mangoapp` flag, checks to see if the `mango app` command exists, then applies the `--mangoapp` flag in the variable. If `mangoapp` does not exist then a message is sent stating to check that MangoHud is installed and to proceed without the `--mangoapp` flag.

That variable is then used in the gamescope command.