### PR TITLE
41 add checks if mangohud is installed then use the   mangoapp flag

### DIFF
--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -3,7 +3,9 @@
 # Assume that MangoHud is not installed
 MANGOAPP_FLAG=""
 
-# Check that mangoapp is available to see 
+# Check that mangoapp is available. Set the flag if it exists,
+# otherwise inform to check that MangoHud is installed and
+# proceed without the flag.
 if command -v mangoapp &> /dev/null;
 then
     MANGOAPP_FLAG="--mangoapp"

--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-gamescope --mangoapp -e -- steam -steamdeck -steamos3
+# Assume that MangoHud is not installed
+MANGOAPP_FLAG=""
+
+# Check that mangoapp is available to see 
+if command -v mangoapp &> /dev/null;
+then
+    MANGOAPP_FLAG="--mangoapp"
+else
+    printf "[%s] [Info] 'mangoapp' is not available on your system. Check to see that MangoHud is installed.\n" $0
+    printf "[%s] [Info] Continuing without the '--mangoapp' flag.\n" $0
+fi
+
+gamescope \
+    $MANGOAPP_FLAG \
+    -e -- steam -steamdeck -steamos3


### PR DESCRIPTION
Updated to include a completed comment when checking if `mangoapp` exists:

This update includes a variable for the `--mangoapp` flag but set to empty at start. If the `mangoapp` exists then the variable is populated with the `--mangoapp` flag. Otherwise, a message stating to check that MangoHud is installed, and proceeds without populating the `--mangoapp` flag.