### PR TITLE
Added selection of the first GPU with connected display

### DIFF
--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -14,6 +14,20 @@ else
     printf "[%s] [Info] Continuing without the '--mangoapp' flag.\n" $0
 fi
 
+PREFER_DEVICE=""
+
+for card in /sys/class/drm/card[0-9]*; do
+  for output in "$card"-*; do
+    if [ -e "$output/status" ] && [ $(cat "$output/status") = "connected" ]; then
+        read vendor <"${card}/device/vendor"
+        read device <"${card}/device/device"
+        PREFER_DEVICE="--prefer-vk-device "${vendor#0x}:${device#0x}""
+        break 2
+    fi
+  done
+done
+
+
 gamescope \
-    $MANGOAPP_FLAG \
+    ${MANGOAPP_FLAG} ${PREFER_DEVICE} \
     -e -- steam -steamdeck -steamos3


### PR DESCRIPTION
On a laptop with integrated and discrete GPUs, Gamescope may not work if all displays are connected to the iGPU (https://github.com/ValveSoftware/gamescope/issues/1469)

This PR asks Gamescope to use the first GPU with a connected output